### PR TITLE
Fix README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-This repository has moved: find the most recent and maintained version at: [github.com/HeydenLabASU-collab/FRESEAN-metadynamics](github.com/HeydenLabASU-collab/FRESEAN-metadynamics)
+This repository has moved: find the most recent and maintained version at: [github.com/HeydenLabASU-collab/FRESEAN-metadynamics](https://github.com/HeydenLabASU-collab/FRESEAN-metadynamics)


### PR DESCRIPTION
The link in the README is interpreted as https://github.com/HeydenLabASU/FRESEAN-metadynamics/blob/main/github.com/HeydenLabASU-collab/FRESEAN-metadynamics (I think GitHub is trying to be helpful and interpret it as a directory in the local repo and not a URL). This PR fixes it to redirect to the correct  URL.